### PR TITLE
feature/pokemon 005 CreateV1 endpoint 

### DIFF
--- a/.covignore
+++ b/.covignore
@@ -1,0 +1,3 @@
+cmd/api/main.go
+cmd/pokemon/mocks.go
+internal/pokemon/mocks.go

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,7 @@
 
 ### Transactions / Endpoints
 - [ ] All
-- [ ] GET /pokemons
-- [ ] GET /pokemons/types
-- [ ] POST /pokemon
-- [ ] GET /pokemon/:pokemon_id
-
+- [ ] GET /pokemons/v1
+- [ ] GET /pokemons/types/v1
+- [ ] POST /pokemon/v1
+- [ ] GET /pokemon/:pokemon_id/v1

--- a/automatedtests/postman/[Integration Tests]- PI- Pokemon.postman_collection.json
+++ b/automatedtests/postman/[Integration Tests]- PI- Pokemon.postman_collection.json
@@ -1,0 +1,205 @@
+{
+	"info": {
+		"_postman_id": "996e1c8d-7154-47c7-aab3-b54fb139fe97",
+		"name": "[Integration Tests]- PI- Pokemon",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "18593853"
+	},
+	"item": [
+		{
+			"name": "SearchV1",
+			"item": []
+		},
+		{
+			"name": "SearchByIDV1",
+			"item": []
+		},
+		{
+			"name": "CreateV1",
+			"item": [
+				{
+					"name": "Success cases",
+					"item": [
+						{
+							"name": "CreateV1 -OK",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 204\",",
+											"function(){",
+											"    pm.response.to.have.status(204)",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"name\": \"test2\",\n\t\"hp\": 35,\n\t\"attack\": 55,\n\t\"defense\": 40,\n\t\"speed\": 90,\n\t\"height\": 4,\n\t\"weight\": 60,\n    \"created\": true,\n\t\"types\" : [\n        {\n         \"name\": \"poison\"\n        },\n        {\n          \"name\": \"grass\"\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{localhost}}/pokemon/v1",
+									"host": [
+										"{{localhost}}"
+									],
+									"path": [
+										"pokemon",
+										"v1"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Fail cases",
+					"item": [
+						{
+							"name": "CreateV1 - User repeated",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 400\",",
+											"function(){",
+											"    pm.response.to.have.status(400)",
+											"})",
+											"",
+											"pm.test(`",
+											"\t\"code\" :\"bad_request\"",
+											"\t\"message\": \"invalid pokemon\"",
+											"`, () => {",
+											"    const responseJson = pm.response.json();",
+											"    pm.expect(responseJson[\"code\"]).to.eql(\"bad_request\");",
+											"    pm.expect(responseJson[\"message\"]).to.eql(\"invalid pokemon\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"name\": \"test2\",\n\t\"hp\": 35,\n\t\"attack\": 55,\n\t\"defense\": 40,\n\t\"speed\": 90,\n\t\"height\": 4,\n\t\"weight\": 60,\n    \"created\": true,\n\t\"types\" : [\n        {\n         \"name\": \"poison\"\n        },\n        {\n          \"name\": \"grass\"\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{localhost}}/pokemon/v1",
+									"host": [
+										"{{localhost}}"
+									],
+									"path": [
+										"pokemon",
+										"v1"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "CreateV1 - User with invalid body",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 400\",",
+											"function(){",
+											"    pm.response.to.have.status(400)",
+											"})",
+											"",
+											"pm.test(`",
+											"\t\"code\" :\"bad_request\"",
+											"\t\"message\": \"invalid body\"",
+											"`, () => {",
+											"    const responseJson = pm.response.json();",
+											"    pm.expect(responseJson[\"code\"]).to.eql(\"bad_request\");",
+											"    pm.expect(responseJson[\"message\"]).to.eql(\"invalid body\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"hp\": 35,\n\t\"attack\": 55,\n\t\"defense\": 40,\n\t\"speed\": 90,\n\t\"height\": 4,\n\t\"weight\": 60,\n    \"created\": true,\n\t\"types\" : [\n        {\n         \"name\": \"poison\"\n        },\n        {\n          \"name\": \"grass\"\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{localhost}}/pokemon/v1",
+									"host": [
+										"{{localhost}}"
+									],
+									"path": [
+										"pokemon",
+										"v1"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "SearchTypesV1",
+			"item": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "localhost",
+			"value": "http://localhost:8080",
+			"type": "string"
+		}
+	]
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	pokemonsSearchV1      string = "/pokemons"
-	pokemonsSearchTypesV1 string = "/pokemons/types"
-	pokemonCreateV1       string = "/pokemon"
-	pokemonSearchByIDV1   string = "/pokemon/{pokemon_id}"
+	pokemonsSearchV1      string = "/pokemons/v1"
+	pokemonsSearchTypesV1 string = "/pokemons/types/v1"
+	pokemonCreateV1       string = "/pokemon/v1"
+	pokemonSearchByIDV1   string = "/pokemon/{pokemon_id}/v1"
 
 	// connectionStringFormat when its deployed needs to have the host next to @tcp, check https://github.com/go-sql-driver/mysql/
 	connectionStringFormat string = "%s:%s@tcp/%s?charset=utf8&parseTime=true"

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -53,7 +53,7 @@ func run() error {
 	/*
 		Injections
 	*/
-	_ = pokemon.MakeMySQLCreate(pokemonsDBClient)
+	createPokemon := pokemon.MakeMySQLCreate(pokemonsDBClient)
 	if err != nil {
 		panic(err)
 	}
@@ -64,7 +64,7 @@ func run() error {
 	app.Get(pokemonsSearchV1, pokemon.SearchV1())
 	app.Get(pokemonsSearchTypesV1, pokemon.SearchTypesV1())
 
-	app.Post(pokemonCreateV1, pokemon.CreateV1())
+	app.Post(pokemonCreateV1, pokemon.CreateV1(createPokemon))
 	app.Get(pokemonSearchByIDV1, pokemon.SearchByIDV1())
 
 	log.Print("server up and running in port 8080")

--- a/cmd/api/pokemon/create.go
+++ b/cmd/api/pokemon/create.go
@@ -20,13 +20,17 @@ type MySQLCreate func(ctx context.Context, pokemon Pokemon) error
 // MakeMySQLCreate creates a new MySQLCreate
 func MakeMySQLCreate(db *sql.DB) MySQLCreate {
 	return func(ctx context.Context, pokemon Pokemon) error {
+		if pokemon.Image == "" {
+			pokemon.Image = defaultImage
+		}
+
 		stmt, err := db.PrepareContext(ctx, queryInsert)
 		if err != nil {
 			log.Error(ctx, err.Error())
 			return ErrCantPrepareStatement
 		}
 
-		_, err = stmt.ExecContext(ctx, pokemon.ID, pokemon.Name, pokemon.HP, pokemon.Attack, pokemon.Defense, defaultImage, pokemon.Speed, pokemon.Height, pokemon.Weight, pokemon.Created)
+		_, err = stmt.ExecContext(ctx, pokemon.ID, pokemon.Name, pokemon.HP, pokemon.Attack, pokemon.Defense, pokemon.Image, pokemon.Speed, pokemon.Height, pokemon.Weight, pokemon.Created)
 		if err != nil {
 			log.Error(ctx, err.Error())
 			return ErrCantRunQuery

--- a/cmd/api/pokemon/create.go
+++ b/cmd/api/pokemon/create.go
@@ -8,11 +8,7 @@ import (
 	"github.com/rromero96/roro-lib/cmd/log"
 )
 
-const (
-	queryInsert string = "INSERT INTO pokemon (id, name, hp, attack, defense, image, speed, height, weight, created) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-
-	defaultImage string = "https://pokeapi.co/api/v2/pokemon/1/"
-)
+const queryInsert string = "INSERT INTO pokemon (id, name, hp, attack, defense, image, speed, height, weight, created) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 // MySQLCreateFunc serves to create a new row into "pokemons" database
 type MySQLCreate func(ctx context.Context, pokemon Pokemon) error
@@ -20,10 +16,6 @@ type MySQLCreate func(ctx context.Context, pokemon Pokemon) error
 // MakeMySQLCreate creates a new MySQLCreate
 func MakeMySQLCreate(db *sql.DB) MySQLCreate {
 	return func(ctx context.Context, pokemon Pokemon) error {
-		if pokemon.Image == "" {
-			pokemon.Image = defaultImage
-		}
-
 		stmt, err := db.PrepareContext(ctx, queryInsert)
 		if err != nil {
 			log.Error(ctx, err.Error())

--- a/cmd/api/pokemon/dto.go
+++ b/cmd/api/pokemon/dto.go
@@ -1,20 +1,44 @@
 package pokemon
 
 type PokemonDTO struct {
-	ID      string    `json:"id"`
-	Name    string    `json:"name"`
-	HP      int       `json:"hp"`
-	Attack  int       `json:"attack"`
-	Defense int       `json:"defense"`
-	Image   string    `json:"image"`
-	Speed   int       `json:"speed"`
-	Height  int       `json:"height"`
-	Weight  int       `json:"weight"`
-	Created bool      `json:"created"`
+	ID      *string   `json:"id,omitempty"`
+	Name    *string   `json:"name"`
+	HP      *int      `json:"hp"`
+	Attack  *int      `json:"attack"`
+	Defense *int      `json:"defense"`
+	Image   *string   `json:"image,,omitempty"`
+	Speed   *int      `json:"speed"`
+	Height  *int      `json:"height"`
+	Weight  *int      `json:"weight"`
+	Created *bool     `json:"created"`
 	Types   []TypeDTO `json:"types"`
 }
 
 type TypeDTO struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID   *string `json:"id,omitempty"`
+	Name *string `json:"name"`
+}
+
+func (p PokemonDTO) validate() error {
+	if p.Name == nil || p.HP == nil || p.Attack == nil || p.Defense == nil || p.Speed == nil || p.Height == nil || p.Weight == nil {
+		return ErrInvalidBody
+	}
+
+	if p.Types == nil || len(p.Types) == 0 {
+		return ErrInvalidBody
+	}
+
+	for _, v := range p.Types {
+		return v.validate()
+	}
+
+	return nil
+}
+
+func (t TypeDTO) validate() error {
+	if t.Name == nil {
+		return ErrInvalidBody
+	}
+
+	return nil
 }

--- a/cmd/api/pokemon/dto.go
+++ b/cmd/api/pokemon/dto.go
@@ -42,3 +42,30 @@ func (t TypeDTO) validate() error {
 
 	return nil
 }
+
+func (p PokemonDTO) toDomain() Pokemon {
+	return Pokemon{
+		ID:      *p.ID,
+		Name:    *p.Name,
+		HP:      *p.HP,
+		Attack:  *p.Attack,
+		Defense: *p.Defense,
+		Image:   *p.Image,
+		Speed:   *p.Speed,
+		Height:  *p.Height,
+		Weight:  *p.Weight,
+		Created: *p.Created,
+		Types:   toTypes(p.Types),
+	}
+}
+
+func toTypes(typesDTO []TypeDTO) []Type {
+	types := make([]Type, len(typesDTO))
+	for i, v := range typesDTO {
+		types[i] = Type{
+			Name: *v.Name,
+		}
+	}
+
+	return types
+}

--- a/cmd/api/pokemon/dto.go
+++ b/cmd/api/pokemon/dto.go
@@ -1,7 +1,9 @@
 package pokemon
 
+const imageDefault string = "https://pokeapi.co/api/v2/pokemon/1/"
+
 type PokemonDTO struct {
-	ID      *string   `json:"id,omitempty"`
+	ID      *int      `json:"id,omitempty"`
 	Name    *string   `json:"name"`
 	HP      *int      `json:"hp"`
 	Attack  *int      `json:"attack"`
@@ -44,17 +46,32 @@ func (t TypeDTO) validate() error {
 }
 
 func (p PokemonDTO) toDomain() Pokemon {
+	id := 0
+	if p.ID != nil {
+		id = *p.ID
+	}
+
+	image := imageDefault
+	if p.Image != nil {
+		image = *p.Image
+	}
+
+	created := false
+	if p.Created != nil {
+		created = *p.Created
+	}
+
 	return Pokemon{
-		ID:      *p.ID,
+		ID:      id,
 		Name:    *p.Name,
 		HP:      *p.HP,
 		Attack:  *p.Attack,
 		Defense: *p.Defense,
-		Image:   *p.Image,
+		Image:   image,
 		Speed:   *p.Speed,
 		Height:  *p.Height,
 		Weight:  *p.Weight,
-		Created: *p.Created,
+		Created: created,
 		Types:   toTypes(p.Types),
 	}
 }

--- a/cmd/api/pokemon/dto__internal_test.go
+++ b/cmd/api/pokemon/dto__internal_test.go
@@ -1,0 +1,43 @@
+package pokemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPokemon_Validate_success(t *testing.T) {
+	pokemon := MockPokemonDTO()
+
+	got := pokemon.validate()
+
+	assert.Nil(t, got)
+}
+
+func TestPokemon_Validate_failsWithInvalidBody(t *testing.T) {
+	pokemon := MockPokemonDTO()
+	pokemon.Types = nil
+
+	want := ErrInvalidBody
+	got := pokemon.validate()
+
+	assert.Equal(t, got, want)
+}
+
+func TestTypes_Validate_success(t *testing.T) {
+	types := MockTypesDTO()
+
+	got := types[0].validate()
+
+	assert.Nil(t, got)
+}
+
+func TestTypes_Validate_failsWithInvalidBody(t *testing.T) {
+	types := MockTypesDTO()
+	types[0].Name = nil
+
+	want := ErrInvalidBody
+	got := types[0].validate()
+
+	assert.Equal(t, got, want)
+}

--- a/cmd/api/pokemon/dto__internal_test.go
+++ b/cmd/api/pokemon/dto__internal_test.go
@@ -41,3 +41,21 @@ func TestTypes_Validate_failsWithInvalidBody(t *testing.T) {
 
 	assert.Equal(t, got, want)
 }
+
+func TestPokemon_ToDomain_success(t *testing.T) {
+	pokemon := MockPokemonDTO()
+
+	want := MockPokemon()
+	got := pokemon.toDomain()
+
+	assert.Equal(t, got, want)
+}
+
+func TestToTypes_success(t *testing.T) {
+	types := MockTypesDTO()
+
+	want := MockTypes()
+	got := toTypes(types)
+
+	assert.Equal(t, got, want)
+}

--- a/cmd/api/pokemon/errors.go
+++ b/cmd/api/pokemon/errors.go
@@ -11,5 +11,7 @@ var (
 )
 
 const (
-	InvalidBody string = "invalid body"
+	InvalidBody       string = "invalid body"
+	BadRequest        string = "bad request"
+	CantCreatePokemon string = "can't create pokemon"
 )

--- a/cmd/api/pokemon/errors.go
+++ b/cmd/api/pokemon/errors.go
@@ -3,8 +3,13 @@ package pokemon
 import "errors"
 
 var (
+	ErrInvalidBody          = errors.New(InvalidBody)
 	ErrCantPrepareStatement = errors.New("can't prepare statement")
 	ErrCantRunQuery         = errors.New("can't run query")
 	ErrCantScanRowResult    = errors.New("can't scan row result")
 	ErrCantReadRows         = errors.New("can't read rows")
+)
+
+const (
+	InvalidBody string = "invalid body"
 )

--- a/cmd/api/pokemon/errors.go
+++ b/cmd/api/pokemon/errors.go
@@ -12,6 +12,6 @@ var (
 
 const (
 	InvalidBody       string = "invalid body"
-	BadRequest        string = "bad request"
+	InvalidPokemon    string = "invalid pokemon"
 	CantCreatePokemon string = "can't create pokemon"
 )

--- a/cmd/api/pokemon/handler_web.go
+++ b/cmd/api/pokemon/handler_web.go
@@ -1,6 +1,7 @@
 package pokemon
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/rromero96/roro-lib/cmd/web"
@@ -26,6 +27,16 @@ func CreateV1(createPokemon MySQLCreate) web.Handler {
 		var body PokemonDTO
 		if web.DecodeJSON(r, &body) != nil || body.validate() != nil {
 			return web.NewError(http.StatusBadRequest, InvalidBody)
+		}
+
+		err := createPokemon(r.Context(), body.toDomain())
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrCantRunQuery):
+				return web.NewError(http.StatusBadRequest, BadRequest)
+			default:
+				return web.NewError(http.StatusInternalServerError, CantCreatePokemon)
+			}
 		}
 
 		return web.EncodeJSON(w, "", http.StatusNoContent)

--- a/cmd/api/pokemon/handler_web.go
+++ b/cmd/api/pokemon/handler_web.go
@@ -33,7 +33,7 @@ func CreateV1(createPokemon MySQLCreate) web.Handler {
 		if err != nil {
 			switch {
 			case errors.Is(err, ErrCantRunQuery):
-				return web.NewError(http.StatusBadRequest, BadRequest)
+				return web.NewError(http.StatusBadRequest, InvalidPokemon)
 			default:
 				return web.NewError(http.StatusInternalServerError, CantCreatePokemon)
 			}

--- a/cmd/api/pokemon/handler_web.go
+++ b/cmd/api/pokemon/handler_web.go
@@ -21,9 +21,14 @@ func SearchByIDV1() web.Handler {
 }
 
 // CreateV1 perfoms a pokemon creation
-func CreateV1() web.Handler {
+func CreateV1(createPokemon MySQLCreate) web.Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		return nil
+		var body PokemonDTO
+		if web.DecodeJSON(r, &body) != nil || body.validate() != nil {
+			return web.NewError(http.StatusBadRequest, InvalidBody)
+		}
+
+		return web.EncodeJSON(w, "", http.StatusNoContent)
 	}
 }
 

--- a/cmd/api/pokemon/handler_web_test.go
+++ b/cmd/api/pokemon/handler_web_test.go
@@ -1,0 +1,37 @@
+package pokemon_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rromero96/PI-Pokemon/cmd/api/pokemon"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPHandler_CreateV1_success(t *testing.T) {
+	createPokemon := pokemon.MockMySQLCreate(nil)
+	createV1 := pokemon.CreateV1(createPokemon)
+	bodyJSON := pokemon.MockPokemonAsJson()
+
+	ctx, w := context.Background(), httptest.NewRecorder()
+	r, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/test", strings.NewReader(bodyJSON))
+
+	got := createV1(w, r)
+
+	assert.Nil(t, got)
+}
+
+func TestHTTPHandler__failsWhenBodyIsInvalid(t *testing.T) {
+
+}
+
+func TestHTTPHandler__failsWithBadRequest(t *testing.T) {
+
+}
+
+func TestHTTPHandler__failsWithInternalServerError(t *testing.T) {
+
+}

--- a/cmd/api/pokemon/handler_web_test.go
+++ b/cmd/api/pokemon/handler_web_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/rromero96/PI-Pokemon/cmd/api/pokemon"
+	"github.com/rromero96/roro-lib/cmd/web"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,13 +26,43 @@ func TestHTTPHandler_CreateV1_success(t *testing.T) {
 }
 
 func TestHTTPHandler__failsWhenBodyIsInvalid(t *testing.T) {
+	createPokemon := pokemon.MockMySQLCreate(nil)
+	createV1 := pokemon.CreateV1(createPokemon)
+	bodyJSON := pokemon.InvalidBody
 
+	ctx, w := context.Background(), httptest.NewRecorder()
+	r, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/test", strings.NewReader(bodyJSON))
+
+	want := web.NewError(http.StatusBadRequest, pokemon.InvalidBody)
+	got := createV1(w, r)
+
+	assert.Equal(t, got, want)
 }
 
 func TestHTTPHandler__failsWithBadRequest(t *testing.T) {
+	createPokemon := pokemon.MockMySQLCreate(pokemon.ErrCantRunQuery)
+	createV1 := pokemon.CreateV1(createPokemon)
+	bodyJSON := pokemon.MockPokemonAsJson()
 
+	ctx, w := context.Background(), httptest.NewRecorder()
+	r, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/test", strings.NewReader(bodyJSON))
+
+	want := web.NewError(http.StatusBadRequest, pokemon.InvalidPokemon)
+	got := createV1(w, r)
+
+	assert.Equal(t, got, want)
 }
 
 func TestHTTPHandler__failsWithInternalServerError(t *testing.T) {
+	createPokemon := pokemon.MockMySQLCreate(pokemon.ErrCantPrepareStatement)
+	createV1 := pokemon.CreateV1(createPokemon)
+	bodyJSON := pokemon.MockPokemonAsJson()
 
+	ctx, w := context.Background(), httptest.NewRecorder()
+	r, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/test", strings.NewReader(bodyJSON))
+
+	want := web.NewError(http.StatusInternalServerError, pokemon.CantCreatePokemon)
+	got := createV1(w, r)
+
+	assert.Equal(t, got, want)
 }

--- a/cmd/api/pokemon/handler_web_test.go
+++ b/cmd/api/pokemon/handler_web_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rromero96/PI-Pokemon/cmd/api/pokemon"
 	"github.com/rromero96/roro-lib/cmd/web"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/rromero96/PI-Pokemon/cmd/api/pokemon"
 )
 
 func TestHTTPHandler_CreateV1_success(t *testing.T) {

--- a/cmd/api/pokemon/mocks.go
+++ b/cmd/api/pokemon/mocks.go
@@ -46,6 +46,11 @@ func MockPokemon() Pokemon {
 	}
 }
 
+// MockPokemonDTO mock
+func MockPokemonDTO() PokemonDTO {
+	return MockPokemon().toDTO()
+}
+
 // MockTypes  mock
 func MockTypes() []Type {
 	return []Type{
@@ -55,6 +60,12 @@ func MockTypes() []Type {
 	}
 }
 
+// MockTypesDTO
+func MockTypesDTO() []TypeDTO {
+	return toTypesDTO(MockTypes())
+}
+
+// MockTypesAsJson mock
 func MockTypesAsJson() string {
 	return `
 	[

--- a/cmd/api/pokemon/mocks.go
+++ b/cmd/api/pokemon/mocks.go
@@ -20,7 +20,7 @@ func MockPokemonAsJson() string {
 		"name": "pikachu",
 		"hp": 35,
 		"attack": 55,
-		"defesense": 40,
+		"defense": 40,
 		"image": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/dream-world/25.svg",
 		"speed": 90,
 		"height": 4,

--- a/cmd/api/pokemon/mocks.go
+++ b/cmd/api/pokemon/mocks.go
@@ -16,7 +16,7 @@ func MockMySQLCreate(err error) MySQLCreate {
 func MockPokemonAsJson() string {
 	return fmt.Sprintf(`
 	{
-		"id": "25",
+		"id": 25,
 		"name": "pikachu",
 		"hp": 35,
 		"attack": 55,
@@ -33,7 +33,7 @@ func MockPokemonAsJson() string {
 // MockPokemon mock
 func MockPokemon() Pokemon {
 	return Pokemon{
-		ID:      "25",
+		ID:      25,
 		Name:    "pikachu",
 		HP:      35,
 		Attack:  55,

--- a/cmd/api/pokemon/types.go
+++ b/cmd/api/pokemon/types.go
@@ -18,3 +18,30 @@ type Type struct {
 	ID   string
 	Name string
 }
+
+func (p Pokemon) toDTO() PokemonDTO {
+	return PokemonDTO{
+		ID:      &p.ID,
+		Name:    &p.Name,
+		HP:      &p.HP,
+		Attack:  &p.Attack,
+		Defense: &p.Defense,
+		Image:   &p.Image,
+		Speed:   &p.Speed,
+		Height:  &p.Height,
+		Weight:  &p.Weight,
+		Created: &p.Created,
+		Types:   toTypesDTO(p.Types),
+	}
+}
+
+func toTypesDTO(types []Type) []TypeDTO {
+	typesDTO := make([]TypeDTO, len(types))
+	for i, v := range types {
+		typesDTO[i] = TypeDTO{
+			Name: &v.Name,
+		}
+	}
+
+	return typesDTO
+}

--- a/cmd/api/pokemon/types.go
+++ b/cmd/api/pokemon/types.go
@@ -1,7 +1,7 @@
 package pokemon
 
 type Pokemon struct {
-	ID      string
+	ID      int
 	Name    string
 	HP      int
 	Attack  int

--- a/cmd/api/pokemon/types_internal_test.go
+++ b/cmd/api/pokemon/types_internal_test.go
@@ -1,0 +1,25 @@
+package pokemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPokemon_ToDTO_success(t *testing.T) {
+	pokemon := MockPokemon()
+
+	want := MockPokemonDTO()
+	got := pokemon.toDTO()
+
+	assert.Equal(t, got, want)
+}
+
+func TestToTypesDTO_succes(t *testing.T) {
+	types := MockTypes()
+
+	want := MockTypesDTO()
+	got := toTypesDTO(types)
+
+	assert.Equal(t, got, want)
+}


### PR DESCRIPTION
## Description
- Injection and logic add to CreateV1 endpoint
- validate, to domain and to dto funtions add
- covignore file add
- postman collection add
- mocks add
- unit testing add

## Affected Flows
- none

### Transactions / Endpoints
- [ ] All
- [ ] GET /pokemons/v1
- [ ] GET /pokemons/types/v1
- [X] POST /pokemon/v1
- [ ] GET /pokemon/:pokemon_id/v1

