### PR TITLE
feature/pokemon 006 Types relationship add in DB

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -53,7 +53,12 @@ func run() error {
 	/*
 		Injections
 	*/
-	createPokemon := pokemon.MakeMySQLCreate(pokemonsDBClient)
+	addTypes := pokemon.MakeMySQLAdd(pokemonsDBClient)
+	if err != nil {
+		panic(err)
+	}
+
+	createPokemon := pokemon.MakeMySQLCreate(pokemonsDBClient, addTypes)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/api/pokemon/create.go
+++ b/cmd/api/pokemon/create.go
@@ -2,32 +2,72 @@ package pokemon
 
 import (
 	"context"
+	"strings"
 
 	"database/sql"
 
 	"github.com/rromero96/roro-lib/cmd/log"
 )
 
-const queryInsert string = "INSERT INTO pokemon (id, name, hp, attack, defense, image, speed, height, weight, created) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+const (
+	queryCreate string = "INSERT INTO pokemon (id, name, hp, attack, defense, image, speed, height, weight, created) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"
+	queryAdd    string = "INSERT INTO pokemon_type (pokemon_id, type_name) VALUES "
+)
 
-// MySQLCreateFunc serves to create a new row into "pokemons" database
-type MySQLCreate func(ctx context.Context, pokemon Pokemon) error
+type (
+	// MySQLCreate serves to create a new row into "pokemons" database
+	MySQLCreate func(ctx context.Context, pokemon Pokemon) error
+
+	// MySQLAdd serves to add a new relationships between "pokemons" and "types" schemas
+	MySQLAdd func(ctx context.Context, ID int, types []Type) error
+)
 
 // MakeMySQLCreate creates a new MySQLCreate
 func MakeMySQLCreate(db *sql.DB) MySQLCreate {
 	return func(ctx context.Context, pokemon Pokemon) error {
-		stmt, err := db.PrepareContext(ctx, queryInsert)
+		stmt, err := db.PrepareContext(ctx, queryCreate)
 		if err != nil {
 			log.Error(ctx, err.Error())
 			return ErrCantPrepareStatement
 		}
+		defer stmt.Close()
 
 		_, err = stmt.ExecContext(ctx, pokemon.ID, pokemon.Name, pokemon.HP, pokemon.Attack, pokemon.Defense, pokemon.Image, pokemon.Speed, pokemon.Height, pokemon.Weight, pokemon.Created)
 		if err != nil {
 			log.Error(ctx, err.Error())
 			return ErrCantRunQuery
 		}
+
+		return nil
+	}
+}
+
+// MakeMySQLAdd creates a new MySQLAdd
+func MakeMySQLAdd(db *sql.DB) MySQLAdd {
+	return func(ctx context.Context, ID int, types []Type) error {
+		var inserts []string
+		var params []interface{}
+
+		for _, t := range types {
+			inserts = append(inserts, "(?, ?)")
+			params = append(params, ID, t.Name)
+		}
+
+		queryVals := strings.Join(inserts, ",")
+		query := queryAdd + queryVals
+
+		stmt, err := db.PrepareContext(ctx, query)
+		if err != nil {
+			log.Error(ctx, err.Error())
+			return ErrCantPrepareStatement
+		}
 		defer stmt.Close()
+
+		_, err = stmt.ExecContext(ctx, params...)
+		if err != nil {
+			log.Error(ctx, err.Error())
+			return ErrCantRunQuery
+		}
 
 		return nil
 	}

--- a/cmd/api/pokemon/create.go
+++ b/cmd/api/pokemon/create.go
@@ -40,11 +40,13 @@ func MakeMySQLCreate(db *sql.DB, addTypes MySQLAdd) MySQLCreate {
 
 		id, err := p.LastInsertId()
 		if err != nil {
+			log.Error(ctx, err.Error())
 			return ErrCantGetLastID
 		}
 
 		err = addTypes(ctx, int(id), pokemon.Types)
 		if err != nil {
+			log.Error(ctx, err.Error())
 			return ErrCantAddTypes
 		}
 

--- a/cmd/api/pokemon/errors.go
+++ b/cmd/api/pokemon/errors.go
@@ -8,6 +8,8 @@ var (
 	ErrCantRunQuery         = errors.New("can't run query")
 	ErrCantScanRowResult    = errors.New("can't scan row result")
 	ErrCantReadRows         = errors.New("can't read rows")
+	ErrCantAddTypes         = errors.New("can't add types")
+	ErrCantGetLastID        = errors.New("can't get last id")
 )
 
 const (

--- a/cmd/api/pokemon/mocks.go
+++ b/cmd/api/pokemon/mocks.go
@@ -12,6 +12,13 @@ func MockMySQLCreate(err error) MySQLCreate {
 	}
 }
 
+// MockMySQLCreate
+func MockMySQLAdd(err error) MySQLAdd {
+	return func(context.Context, int, []Type) error {
+		return err
+	}
+}
+
 // MockPokemonAsJson mock
 func MockPokemonAsJson() string {
 	return fmt.Sprintf(`

--- a/sql/pokemons_pokemon_type.sql
+++ b/sql/pokemons_pokemon_type.sql
@@ -1,5 +1,3 @@
-CREATE DATABASE  IF NOT EXISTS `pokemons` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */;
-USE `pokemons`;
 -- MySQL dump 10.13  Distrib 8.0.27, for macos11 (x86_64)
 --
 -- Host: localhost    Database: pokemons
@@ -26,11 +24,11 @@ DROP TABLE IF EXISTS `pokemon_type`;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `pokemon_type` (
   `pokemon_id` int NOT NULL,
-  `type_id` int NOT NULL,
-  PRIMARY KEY (`pokemon_id`,`type_id`),
-  KEY `type_id` (`type_id`),
+  `type_name` varchar(255) NOT NULL,
+  PRIMARY KEY (`pokemon_id`,`type_name`),
+  KEY `pokemon_type_ibfk_2` (`type_name`),
   CONSTRAINT `pokemon_type_ibfk_1` FOREIGN KEY (`pokemon_id`) REFERENCES `pokemon` (`id`),
-  CONSTRAINT `pokemon_type_ibfk_2` FOREIGN KEY (`type_id`) REFERENCES `type` (`id`)
+  CONSTRAINT `pokemon_type_ibfk_2` FOREIGN KEY (`type_name`) REFERENCES `type` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -52,4 +50,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2023-03-29 12:24:51
+-- Dump completed on 2023-04-10 21:15:45


### PR DESCRIPTION
## Description
- MySqlAdd function creation with types, unit tests and mocks
- SQL table change for pokemon_type, so the foreign key for types is the name and not the id
- Instance of MySqlAdd in main.go
- Injection addition and integration of MySqlAdd into MySQLCreate, so the pokemon could be created with the relationship 
- Unit testing update for MySQLCreate with more cases

## Affected Flows
- MySQLCreate

### Transactions / Endpoints
- [ ] All
- [ ] GET /pokemons/v1
- [ ] GET /pokemons/types/v1
- [X] POST /pokemon/v1
- [ ] GET /pokemon/:pokemon_id/v1
