### PR TITLE
feature/pokemon-007 Type Create in DB

### DIFF
--- a/cmd/api/pokemon/mocks.go
+++ b/cmd/api/pokemon/mocks.go
@@ -5,16 +5,23 @@ import (
 	"fmt"
 )
 
-// MockMySQLCreate
+// MockMySQLCreate mock
 func MockMySQLCreate(err error) MySQLCreate {
 	return func(context.Context, Pokemon) error {
 		return err
 	}
 }
 
-// MockMySQLCreate
+// MockMySQLCreate mock
 func MockMySQLAdd(err error) MySQLAdd {
 	return func(context.Context, int, []Type) error {
+		return err
+	}
+}
+
+// MockMySQLCreateType mock
+func MockMySQLCreateType(err error) MySQLCreateType {
+	return func(context.Context, []Type) error {
 		return err
 	}
 }

--- a/cmd/api/pokemon/mysql_create.go
+++ b/cmd/api/pokemon/mysql_create.go
@@ -48,8 +48,7 @@ func MakeMySQLCreate(db *sql.DB, addTypes MySQLAdd) MySQLCreate {
 			return ErrCantGetLastID
 		}
 
-		err = addTypes(ctx, int(id), pokemon.Types)
-		if err != nil {
+		if addTypes(ctx, int(id), pokemon.Types) != nil {
 			log.Error(ctx, err.Error())
 			return ErrCantAddTypes
 		}

--- a/cmd/api/pokemon/mysql_create.go
+++ b/cmd/api/pokemon/mysql_create.go
@@ -10,16 +10,20 @@ import (
 )
 
 const (
-	queryCreate string = "INSERT INTO pokemon (id, name, hp, attack, defense, image, speed, height, weight, created) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"
-	queryAdd    string = "INSERT INTO pokemon_type (pokemon_id, type_name) VALUES "
+	queryCreate     string = "INSERT INTO pokemon (id, name, hp, attack, defense, image, speed, height, weight, created) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+	queryAdd        string = "INSERT INTO pokemon_type (pokemon_id, type_name) VALUES "
+	queryCreateType string = "INSERT INTO type (name) VALUES "
 )
 
 type (
-	// MySQLCreate serves to create a new row into "pokemons" database
+	// MySQLCreate serves to create a new row into "pokemons" schema
 	MySQLCreate func(ctx context.Context, pokemon Pokemon) error
 
 	// MySQLAdd serves to add a new relationships between "pokemons" and "types" schemas
 	MySQLAdd func(ctx context.Context, ID int, types []Type) error
+
+	// MySQLCreate serves to create a new row into "type" schema
+	MySQLCreateType func(ctx context.Context, types []Type) error
 )
 
 // MakeMySQLCreate creates a new MySQLCreate
@@ -67,6 +71,37 @@ func MakeMySQLAdd(db *sql.DB) MySQLAdd {
 
 		queryVals := strings.Join(inserts, ",")
 		query := queryAdd + queryVals
+
+		stmt, err := db.PrepareContext(ctx, query)
+		if err != nil {
+			log.Error(ctx, err.Error())
+			return ErrCantPrepareStatement
+		}
+		defer stmt.Close()
+
+		_, err = stmt.ExecContext(ctx, params...)
+		if err != nil {
+			log.Error(ctx, err.Error())
+			return ErrCantRunQuery
+		}
+
+		return nil
+	}
+}
+
+// MakeMySQLCreateType creates a new MySQLCreateType
+func MakeMySQLCreateType(db *sql.DB) MySQLCreateType {
+	return func(ctx context.Context, types []Type) error {
+		var inserts []string
+		var params []interface{}
+
+		for _, t := range types {
+			inserts = append(inserts, "(?)")
+			params = append(params, t.Name)
+		}
+
+		queryVals := strings.Join(inserts, ",")
+		query := queryCreateType + queryVals
 
 		stmt, err := db.PrepareContext(ctx, query)
 		if err != nil {


### PR DESCRIPTION
## Description
- MySQLCreateType function add, with unit tests and mocks
- file rename to give more readability
- sql table change in autoincrement id

## Affected Flows
- MySQLCreateType

### Transactions / Endpoints
- [ ] All
- [ ] GET /pokemons/v1
- [X] GET /pokemons/types/v1
- [ ] POST /pokemon/v1
- [ ] GET /pokemon/:pokemon_id/v1
