### PR TITLE
feature/Pokemon-016 Create type function

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -80,18 +80,13 @@ func run() error {
 	/*
 		Injections
 	*/
+
 	/*	mysql	*/
 	addTypes := pokemon.MakeMySQLAdd(pokemonsDBClient)
 	mysqlCreate := pokemon.MakeMySQLCreate(pokemonsDBClient, addTypes)
-	mysqlSearchByID, err := pokemon.MakeMySQLSearchByID(pokemonsDBClient)
-	if err != nil {
-		return err
-	}
+	mysqlSearchByID := pokemon.MakeMySQLSearchByID(pokemonsDBClient)
 	mysqlCreateTypes := pokemon.MakeMySQLCreateType(pokemonsDBClient)
-	mysqlSearchTypes, err := pokemon.MakeMySQLSearchTypes(pokemonsDBClient)
-	if err != nil {
-		return err
-	}
+	mysqlSearchTypes := pokemon.MakeMySQLSearchTypes(pokemonsDBClient)
 
 	/*	internal	*/
 	getTypes, err := internalPokemon.MakeGetTypes(httpClient)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -107,6 +107,7 @@ func run() error {
 	/*	api	*/
 	searchTypes := pokemon.MakeSearchTypes(mysqlSearchTypes, getTypes, mysqlCreateTypes)
 	searchByID := pokemon.MakeSearchByID(mysqlSearchByID, getByID, mysqlCreate)
+	create := pokemon.MakeCreate(mysqlCreate)
 
 	/*
 		Endpoints
@@ -114,7 +115,7 @@ func run() error {
 	app.Get(pokemonsSearchV1, pokemon.SearchV1())
 	app.Get(pokemonsSearchTypesV1, pokemon.SearchTypesV1(searchTypes))
 
-	app.Post(pokemonCreateV1, pokemon.CreateV1(mysqlCreate))
+	app.Post(pokemonCreateV1, pokemon.CreateV1(create))
 	app.Get(pokemonSearchByIDV1, pokemon.SearchByIDV1(searchByID))
 
 	log.Print("server up and running in port 8080")

--- a/cmd/api/pokemon/create.go
+++ b/cmd/api/pokemon/create.go
@@ -1,0 +1,32 @@
+package pokemon
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rromero96/roro-lib/log"
+)
+
+type (
+	// Create creates a new pokemon in the db
+	Create func(ctx context.Context, pokemon Pokemon) error
+)
+
+// MakeCreate creates a new Create function
+func MakeCreate(mysqlCreate MySQLCreate) Create {
+	return func(ctx context.Context, pokemon Pokemon) error {
+		pokemon.Custom = true
+
+		err := mysqlCreate(ctx, pokemon)
+		if err != nil {
+			log.Error(ctx, err.Error())
+			if errors.Is(err, ErrCantRunQuery) {
+				return ErrInvalidPokemon
+			}
+
+			return ErrCantCreatePokemon
+		}
+
+		return nil
+	}
+}

--- a/cmd/api/pokemon/created_test.go
+++ b/cmd/api/pokemon/created_test.go
@@ -1,0 +1,53 @@
+package pokemon_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rromero96/PI-Pokemon/cmd/api/pokemon"
+)
+
+func TestMakeCreate_success(t *testing.T) {
+	mysqlCreate := pokemon.MockMySQLCreate(nil)
+
+	got := pokemon.MakeCreate(mysqlCreate)
+
+	assert.NotNil(t, got)
+}
+
+func TestCreate_success(t *testing.T) {
+	mysqlCreate := pokemon.MockMySQLCreate(nil)
+
+	ctx := context.Background()
+	create := pokemon.MakeCreate(mysqlCreate)
+
+	got := create(ctx, pokemon.MockPokemon())
+
+	assert.Nil(t, got)
+}
+
+func TestCreate_failsWhenMySQLCreateThrowsError(t *testing.T) {
+	mysqlCreate := pokemon.MockMySQLCreate(pokemon.ErrCantPrepareStatement)
+
+	ctx := context.Background()
+	create := pokemon.MakeCreate(mysqlCreate)
+
+	want := pokemon.ErrCantCreatePokemon
+	got := create(ctx, pokemon.MockPokemon())
+
+	assert.Equal(t, got, want)
+}
+
+func TestCreate_failsWhenMySQLCreateThrowsErrorOnQuery(t *testing.T) {
+	mysqlCreate := pokemon.MockMySQLCreate(pokemon.ErrCantRunQuery)
+
+	ctx := context.Background()
+	create := pokemon.MakeCreate(mysqlCreate)
+
+	want := pokemon.ErrInvalidPokemon
+	got := create(ctx, pokemon.MockPokemon())
+
+	assert.Equal(t, got, want)
+}

--- a/cmd/api/pokemon/dto.go
+++ b/cmd/api/pokemon/dto.go
@@ -13,7 +13,7 @@ type PokemonDTO struct {
 	Speed   *int      `json:"speed"`
 	Height  *int      `json:"height"`
 	Weight  *int      `json:"weight"`
-	Created *bool     `json:"created"`
+	Custom  *bool     `json:"custom"`
 	Types   []TypeDTO `json:"types"`
 }
 
@@ -61,9 +61,9 @@ func (p PokemonDTO) toDomain() Pokemon {
 		image = *p.Image
 	}
 
-	created := false
-	if p.Created != nil {
-		created = *p.Created
+	custom := false
+	if p.Custom != nil {
+		custom = *p.Custom
 	}
 
 	return Pokemon{
@@ -76,7 +76,7 @@ func (p PokemonDTO) toDomain() Pokemon {
 		Speed:   *p.Speed,
 		Height:  *p.Height,
 		Weight:  *p.Weight,
-		Created: created,
+		Custom:  custom,
 		Types:   toTypes(p.Types),
 	}
 }

--- a/cmd/api/pokemon/errors.go
+++ b/cmd/api/pokemon/errors.go
@@ -17,6 +17,7 @@ var (
 	ErrCantCreatePokemon    = errors.New(CantCreatePokemon)
 	ErrCantSaveTypes        = errors.New("can't save types")
 	ErrPokemonNotFound      = errors.New("pokemon not found")
+	ErrInvalidPokemon       = errors.New(InvalidPokemon)
 )
 
 const (

--- a/cmd/api/pokemon/handler_web.go
+++ b/cmd/api/pokemon/handler_web.go
@@ -39,7 +39,7 @@ func SearchByIDV1(searchByID SearchByID) web.Handler {
 }
 
 // CreateV1 perfoms a pokemon creation
-func CreateV1(createPokemon MySQLCreate) web.Handler {
+func CreateV1(createPokemon Create) web.Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var body PokemonDTO
 		if web.DecodeJSON(r, &body) != nil || body.validate() != nil {
@@ -49,7 +49,7 @@ func CreateV1(createPokemon MySQLCreate) web.Handler {
 		err := createPokemon(r.Context(), body.toDomain())
 		if err != nil {
 			switch {
-			case errors.Is(err, ErrCantRunQuery):
+			case errors.Is(err, ErrInvalidPokemon):
 				return web.NewError(http.StatusBadRequest, InvalidPokemon)
 			default:
 				return web.NewError(http.StatusInternalServerError, CantCreatePokemon)

--- a/cmd/api/pokemon/handler_web_test.go
+++ b/cmd/api/pokemon/handler_web_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestHTTPHandler_CreateV1_success(t *testing.T) {
-	createPokemon := pokemon.MockMySQLCreate(nil)
+	createPokemon := pokemon.MockCreate(nil)
 	createV1 := pokemon.CreateV1(createPokemon)
 	bodyJSON := pokemon.MockPokemonAsJson()
 
@@ -27,7 +27,7 @@ func TestHTTPHandler_CreateV1_success(t *testing.T) {
 }
 
 func TestHTTPHandler_CreateV1_failsWhenBodyIsInvalid(t *testing.T) {
-	createPokemon := pokemon.MockMySQLCreate(nil)
+	createPokemon := pokemon.MockCreate(nil)
 	createV1 := pokemon.CreateV1(createPokemon)
 	bodyJSON := pokemon.InvalidBody
 
@@ -41,7 +41,7 @@ func TestHTTPHandler_CreateV1_failsWhenBodyIsInvalid(t *testing.T) {
 }
 
 func TestHTTPHandler_CreateV1_failsWithBadRequest(t *testing.T) {
-	createPokemon := pokemon.MockMySQLCreate(pokemon.ErrCantRunQuery)
+	createPokemon := pokemon.MockCreate(pokemon.ErrInvalidPokemon)
 	createV1 := pokemon.CreateV1(createPokemon)
 	bodyJSON := pokemon.MockPokemonAsJson()
 
@@ -55,7 +55,7 @@ func TestHTTPHandler_CreateV1_failsWithBadRequest(t *testing.T) {
 }
 
 func TestHTTPHandler_CreateV1_failsWithInternalServerError(t *testing.T) {
-	createPokemon := pokemon.MockMySQLCreate(pokemon.ErrCantPrepareStatement)
+	createPokemon := pokemon.MockCreate(pokemon.ErrCantPrepareStatement)
 	createV1 := pokemon.CreateV1(createPokemon)
 	bodyJSON := pokemon.MockPokemonAsJson()
 

--- a/cmd/api/pokemon/mocks.go
+++ b/cmd/api/pokemon/mocks.go
@@ -54,6 +54,13 @@ func MockSearchByID(pokemon Pokemon, err error) SearchByID {
 	}
 }
 
+// MockCreate mock
+func MockCreate(err error) Create {
+	return func(ctx context.Context, pokemon Pokemon) error {
+		return err
+	}
+}
+
 // MockPokemonAsJson mock
 func MockPokemonAsJson() string {
 	return fmt.Sprintf(`

--- a/cmd/api/pokemon/mysql_create.go
+++ b/cmd/api/pokemon/mysql_create.go
@@ -22,7 +22,7 @@ type (
 
 // MakeMySQLCreate creates a new MySQLCreate
 func MakeMySQLCreate(db *sql.DB, addTypes MySQLAdd) MySQLCreate {
-	var query string = "INSERT INTO pokemon (id, name, hp, attack, defense, image, speed, height, weight, created) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+	var query string = "INSERT INTO pokemon (id, name, hp, attack, defense, image, speed, height, weight, custom) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 	return func(ctx context.Context, pokemon Pokemon) error {
 		stmt, err := db.PrepareContext(ctx, query)
 		if err != nil {
@@ -31,7 +31,7 @@ func MakeMySQLCreate(db *sql.DB, addTypes MySQLAdd) MySQLCreate {
 		}
 		defer stmt.Close()
 
-		p, err := stmt.ExecContext(ctx, pokemon.ID, pokemon.Name, pokemon.HP, pokemon.Attack, pokemon.Defense, pokemon.Image, pokemon.Speed, pokemon.Height, pokemon.Weight, pokemon.Created)
+		p, err := stmt.ExecContext(ctx, pokemon.ID, pokemon.Name, pokemon.HP, pokemon.Attack, pokemon.Defense, pokemon.Image, pokemon.Speed, pokemon.Height, pokemon.Weight, pokemon.Custom)
 		if err != nil {
 			log.Error(ctx, err.Error())
 			return ErrCantRunQuery

--- a/cmd/api/pokemon/mysql_create_test.go
+++ b/cmd/api/pokemon/mysql_create_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	queryCreateMock     string = "INSERT INTO pokemon \\(id, name, hp, attack, defense, image, speed, height, weight, created\\) VALUES \\(\\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?\\)"
+	queryCreateMock     string = "INSERT INTO pokemon \\(id, name, hp, attack, defense, image, speed, height, weight, custom\\) VALUES \\(\\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?\\)"
 	queryAddMock        string = "INSERT INTO pokemon_type \\(pokemon_id, type_name\\) VALUES \\(\\?, \\?\\)"
 	queryCreateTypeMock string = "INSERT INTO type \\(id, name\\) VALUES \\(\\?, \\?\\)"
 )

--- a/cmd/api/pokemon/mysql_search.go
+++ b/cmd/api/pokemon/mysql_search.go
@@ -18,7 +18,7 @@ type (
 // MakeMySQLSearchByID creates a new MySQLSearchByID function
 func MakeMySQLSearchByID(db *sql.DB) (MySQLSearchByID, error) {
 	return func(ctx context.Context, ID int) (Pokemon, error) {
-		const query string = `SELECT id, name, hp, attack, defense, image, speed, height, weight, created, 
+		const query string = `SELECT id, name, hp, attack, defense, image, speed, height, weight, custom, 
 		(SELECT type_name FROM pokemon_type WHERE pokemon_id = id ORDER BY type_name LIMIT 1) AS type_1,
 		(SELECT type_name FROM pokemon_type WHERE pokemon_id = id ORDER BY type_name LIMIT 1,1) AS type_2
 		FROM pokemon
@@ -41,7 +41,7 @@ func MakeMySQLSearchByID(db *sql.DB) (MySQLSearchByID, error) {
 		var pokemon Pokemon
 		for rows.Next() {
 			var type1, type2 sql.NullString
-			if err := rows.Scan(&pokemon.ID, &pokemon.Name, &pokemon.HP, &pokemon.Attack, &pokemon.Defense, &pokemon.Image, &pokemon.Speed, &pokemon.Height, &pokemon.Weight, &pokemon.Created, &type1, &type2); err != nil {
+			if err := rows.Scan(&pokemon.ID, &pokemon.Name, &pokemon.HP, &pokemon.Attack, &pokemon.Defense, &pokemon.Image, &pokemon.Speed, &pokemon.Height, &pokemon.Weight, &pokemon.Custom, &type1, &type2); err != nil {
 				log.Error(ctx, err.Error())
 				return Pokemon{}, ErrCantScanRowResult
 			}

--- a/cmd/api/pokemon/mysql_search.go
+++ b/cmd/api/pokemon/mysql_search.go
@@ -16,7 +16,7 @@ type (
 )
 
 // MakeMySQLSearchByID creates a new MySQLSearchByID function
-func MakeMySQLSearchByID(db *sql.DB) (MySQLSearchByID, error) {
+func MakeMySQLSearchByID(db *sql.DB) MySQLSearchByID {
 	return func(ctx context.Context, ID int) (Pokemon, error) {
 		const query string = `SELECT id, name, hp, attack, defense, image, speed, height, weight, custom, 
 		(SELECT type_name FROM pokemon_type WHERE pokemon_id = id ORDER BY type_name LIMIT 1) AS type_1,
@@ -60,11 +60,11 @@ func MakeMySQLSearchByID(db *sql.DB) (MySQLSearchByID, error) {
 		}
 
 		return pokemon, nil
-	}, nil
+	}
 }
 
 // MakeMySQLSearchTypes creates a new MySQLSearchTypes function
-func MakeMySQLSearchTypes(db *sql.DB) (MySQLSearchTypes, error) {
+func MakeMySQLSearchTypes(db *sql.DB) MySQLSearchTypes {
 	return func(ctx context.Context) ([]Type, error) {
 		const query string = "SELECT id, name FROM type ORDER BY id ASC"
 
@@ -97,5 +97,5 @@ func MakeMySQLSearchTypes(db *sql.DB) (MySQLSearchTypes, error) {
 		}
 
 		return types, nil
-	}, nil
+	}
 }

--- a/cmd/api/pokemon/mysql_search_test.go
+++ b/cmd/api/pokemon/mysql_search_test.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	querySearchTypesMock       string = "SELECT id, name FROM type ORDER BY id ASC"
-	querySearchPokemonByIDMock string = "SELECT id, name, hp, attack, defense, image, speed, height, weight, created, \\(SELECT type_name FROM pokemon_type WHERE pokemon_id = id ORDER BY type_name LIMIT 1\\) AS type_1, \\(SELECT type_name FROM pokemon_type WHERE pokemon_id = id ORDER BY type_name LIMIT 1,1\\) AS type_2 FROM pokemon WHERE id = ?"
+	querySearchPokemonByIDMock string = "SELECT id, name, hp, attack, defense, image, speed, height, weight, custom, \\(SELECT type_name FROM pokemon_type WHERE pokemon_id = id ORDER BY type_name LIMIT 1\\) AS type_1, \\(SELECT type_name FROM pokemon_type WHERE pokemon_id = id ORDER BY type_name LIMIT 1,1\\) AS type_2 FROM pokemon WHERE id = ?"
 )
 
 func TestMakeMySQLSearchType_success(t *testing.T) {
@@ -115,9 +115,9 @@ func TestMySQLSearchType_failsWhenRowResultHasError(t *testing.T) {
 func TestMakeMySQLSearchByID_success(t *testing.T) {
 	db, mock, _ := sqlmock.New()
 	mock.ExpectPrepare(querySearchPokemonByIDMock)
-	id, name, hp, attack, defense, image, speed, height, weight, created, type_1, type_2 := 1, "bulbasaur", 100, 100, 100, "image", 100, 100, 100, false, "grass", "poison"
+	id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2 := 1, "bulbasaur", 100, 100, 100, "image", 100, 100, 100, false, "grass", "poison"
 
-	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "created", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, created, type_1, type_2)
+	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "custom", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2)
 	mock.ExpectQuery(querySearchPokemonByIDMock).WillReturnRows(rows)
 
 	got, err := pokemon.MakeMySQLSearchByID(db)
@@ -129,9 +129,9 @@ func TestMakeMySQLSearchByID_success(t *testing.T) {
 func TestMySQLSearchByID_success(t *testing.T) {
 	db, mock, _ := sqlmock.New()
 	mock.ExpectPrepare(querySearchPokemonByIDMock)
-	id, name, hp, attack, defense, image, speed, height, weight, created, type_1, type_2 := 1, "bulbasaur", 100, 100, 100, "image", 100, 100, 100, false, "grass", "poison"
+	id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2 := 1, "bulbasaur", 100, 100, 100, "image", 100, 100, 100, false, "grass", "poison"
 
-	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "created", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, created, type_1, type_2)
+	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "custom", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2)
 	mock.ExpectQuery(querySearchPokemonByIDMock).WillReturnRows(rows)
 	mysqlSearchByID, _ := pokemon.MakeMySQLSearchByID(db)
 	ctx := context.Background()
@@ -147,9 +147,9 @@ func TestMySQLSearchByID_success(t *testing.T) {
 func TestMySQLSearchByID_failsWhenCantPrepareStatement(t *testing.T) {
 	db, mock, _ := sqlmock.New()
 	mock.ExpectPrepare(pokemon.ErrCantPrepareStatement.Error())
-	id, name, hp, attack, defense, image, speed, height, weight, created, type_1, type_2 := 1, "bulbasaur", 100, 100, 100, "image", 100, 100, 100, false, "grass", "poison"
+	id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2 := 1, "bulbasaur", 100, 100, 100, "image", 100, 100, 100, false, "grass", "poison"
 
-	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "created", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, created, type_1, type_2)
+	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "custom", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2)
 	mock.ExpectQuery(querySearchPokemonByIDMock).WillReturnRows(rows)
 	mysqlSearchByID, _ := pokemon.MakeMySQLSearchByID(db)
 	ctx := context.Background()
@@ -163,9 +163,9 @@ func TestMySQLSearchByID_failsWhenCantPrepareStatement(t *testing.T) {
 func TestMySQLSearchByID_failsWhenCantRunQuery(t *testing.T) {
 	db, mock, _ := sqlmock.New()
 	mock.ExpectPrepare(querySearchPokemonByIDMock)
-	id, name, hp, attack, defense, image, speed, height, weight, created, type_1, type_2 := 1, "bulbasaur", 100, 100, 100, "image", 100, 100, 100, false, "grass", "poison"
+	id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2 := 1, "bulbasaur", 100, 100, 100, "image", 100, 100, 100, false, "grass", "poison"
 
-	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "created", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, created, type_1, type_2)
+	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "custom", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2)
 	mock.ExpectQuery(pokemon.ErrCantRunQuery.Error()).WillReturnRows(rows)
 	mysqlSearchByID, _ := pokemon.MakeMySQLSearchByID(db)
 	ctx := context.Background()
@@ -195,9 +195,9 @@ func TestMySQLSearchByID_failsWhenCantScanRowResult(t *testing.T) {
 func TestMySQLSearchByID_failsWhenRowResultHasError(t *testing.T) {
 	db, mock, _ := sqlmock.New()
 	mock.ExpectPrepare(querySearchPokemonByIDMock)
-	id, name, hp, attack, defense, image, speed, height, weight, created, type_1, type_2 := 1, "bulbasaur", 100, 100, 100, "image", 100, 100, 100, false, "grass", "poison"
+	id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2 := 1, "bulbasaur", 100, 100, 100, "image", 100, 100, 100, false, "grass", "poison"
 
-	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "created", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, created, type_1, type_2).RowError(0, errors.New("some error"))
+	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "custom", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2).RowError(0, errors.New("some error"))
 	mock.ExpectQuery(querySearchPokemonByIDMock).WillReturnRows(rows)
 	mysqlSearchByID, _ := pokemon.MakeMySQLSearchByID(db)
 	ctx := context.Background()

--- a/cmd/api/pokemon/mysql_search_test.go
+++ b/cmd/api/pokemon/mysql_search_test.go
@@ -23,9 +23,8 @@ func TestMakeMySQLSearchType_success(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"id", "name"}).AddRow(id, name)
 	mock.ExpectQuery(querySearchTypesMock).WillReturnRows(rows)
 
-	got, err := pokemon.MakeMySQLSearchTypes(db)
+	got := pokemon.MakeMySQLSearchTypes(db)
 
-	assert.Nil(t, err)
 	assert.NotNil(t, got)
 }
 
@@ -36,7 +35,7 @@ func TestMySQLSearchType_success(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "name"}).AddRow(id, name)
 	mock.ExpectQuery(querySearchTypesMock).WillReturnRows(rows)
-	mysqlSearchType, _ := pokemon.MakeMySQLSearchTypes(db)
+	mysqlSearchType := pokemon.MakeMySQLSearchTypes(db)
 	ctx := context.Background()
 	types := []pokemon.Type{pokemon.MockTypes()[0]}
 	types[0].ID = 1
@@ -56,7 +55,7 @@ func TestMySQLSearchType_failsWhenCantPrepareStatement(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "name"}).AddRow(id, name)
 	mock.ExpectQuery(querySearchTypesMock).WillReturnRows(rows)
-	mysqlSearchType, _ := pokemon.MakeMySQLSearchTypes(db)
+	mysqlSearchType := pokemon.MakeMySQLSearchTypes(db)
 	ctx := context.Background()
 
 	want := pokemon.ErrCantPrepareStatement
@@ -72,7 +71,7 @@ func TestMySQLSearchType_failsWhenCantRunQuery(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "name"}).AddRow(id, name)
 	mock.ExpectQuery(pokemon.ErrCantRunQuery.Error()).WillReturnRows(rows)
-	mysqlSearchType, _ := pokemon.MakeMySQLSearchTypes(db)
+	mysqlSearchType := pokemon.MakeMySQLSearchTypes(db)
 	ctx := context.Background()
 
 	want := pokemon.ErrCantRunQuery
@@ -87,7 +86,7 @@ func TestMySQLSearchType_failsWhenCantScanRowResult(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"invalid column list"}).AddRow("some value")
 	mock.ExpectQuery(querySearchTypesMock).WillReturnRows(rows)
-	mysqlSearchType, _ := pokemon.MakeMySQLSearchTypes(db)
+	mysqlSearchType := pokemon.MakeMySQLSearchTypes(db)
 	ctx := context.Background()
 
 	want := pokemon.ErrCantScanRowResult
@@ -103,7 +102,7 @@ func TestMySQLSearchType_failsWhenRowResultHasError(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "name"}).AddRow(id, name).RowError(0, errors.New("some error"))
 	mock.ExpectQuery(querySearchTypesMock).WillReturnRows(rows)
-	mysqlSearchType, _ := pokemon.MakeMySQLSearchTypes(db)
+	mysqlSearchType := pokemon.MakeMySQLSearchTypes(db)
 	ctx := context.Background()
 
 	want := pokemon.ErrCantReadRows
@@ -120,9 +119,8 @@ func TestMakeMySQLSearchByID_success(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "custom", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2)
 	mock.ExpectQuery(querySearchPokemonByIDMock).WillReturnRows(rows)
 
-	got, err := pokemon.MakeMySQLSearchByID(db)
+	got := pokemon.MakeMySQLSearchByID(db)
 
-	assert.Nil(t, err)
 	assert.NotNil(t, got)
 }
 
@@ -133,7 +131,7 @@ func TestMySQLSearchByID_success(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "custom", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2)
 	mock.ExpectQuery(querySearchPokemonByIDMock).WillReturnRows(rows)
-	mysqlSearchByID, _ := pokemon.MakeMySQLSearchByID(db)
+	mysqlSearchByID := pokemon.MakeMySQLSearchByID(db)
 	ctx := context.Background()
 
 	want := pokemon.MockPokemon()
@@ -151,7 +149,7 @@ func TestMySQLSearchByID_failsWhenCantPrepareStatement(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "custom", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2)
 	mock.ExpectQuery(querySearchPokemonByIDMock).WillReturnRows(rows)
-	mysqlSearchByID, _ := pokemon.MakeMySQLSearchByID(db)
+	mysqlSearchByID := pokemon.MakeMySQLSearchByID(db)
 	ctx := context.Background()
 
 	want := pokemon.ErrCantPrepareStatement
@@ -167,7 +165,7 @@ func TestMySQLSearchByID_failsWhenCantRunQuery(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "custom", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2)
 	mock.ExpectQuery(pokemon.ErrCantRunQuery.Error()).WillReturnRows(rows)
-	mysqlSearchByID, _ := pokemon.MakeMySQLSearchByID(db)
+	mysqlSearchByID := pokemon.MakeMySQLSearchByID(db)
 	ctx := context.Background()
 
 	want := pokemon.ErrCantRunQuery
@@ -183,7 +181,7 @@ func TestMySQLSearchByID_failsWhenCantScanRowResult(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"invalid column list"}).AddRow("some value")
 	mock.ExpectQuery(querySearchPokemonByIDMock).WillReturnRows(rows)
-	mysqlSearchByID, _ := pokemon.MakeMySQLSearchByID(db)
+	mysqlSearchByID := pokemon.MakeMySQLSearchByID(db)
 	ctx := context.Background()
 
 	want := pokemon.ErrCantScanRowResult
@@ -199,7 +197,7 @@ func TestMySQLSearchByID_failsWhenRowResultHasError(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "name", "hp", "attack", "defense", "image", "speed", "height", "weight", "custom", "type_1", "type_2"}).AddRow(id, name, hp, attack, defense, image, speed, height, weight, custom, type_1, type_2).RowError(0, errors.New("some error"))
 	mock.ExpectQuery(querySearchPokemonByIDMock).WillReturnRows(rows)
-	mysqlSearchByID, _ := pokemon.MakeMySQLSearchByID(db)
+	mysqlSearchByID := pokemon.MakeMySQLSearchByID(db)
 	ctx := context.Background()
 
 	want := pokemon.ErrCantReadRows

--- a/cmd/api/pokemon/types.go
+++ b/cmd/api/pokemon/types.go
@@ -15,7 +15,7 @@ type Pokemon struct {
 	Speed   int
 	Height  int
 	Weight  int
-	Created bool
+	Custom  bool
 	Types   []Type
 }
 
@@ -37,7 +37,7 @@ func (p Pokemon) toDTO() PokemonDTO {
 		Speed:   &p.Speed,
 		Height:  &p.Height,
 		Weight:  &p.Weight,
-		Created: &p.Created,
+		Custom:  &p.Custom,
 		Types:   toTypesDTO(p.Types),
 	}
 }

--- a/internal/pokemon/getter.go
+++ b/internal/pokemon/getter.go
@@ -33,7 +33,7 @@ func MakeGetByID(httpClient rusty.Requester) (GetByID, error) {
 		requestOpts := []rusty.RequestOption{
 			rusty.WithParam("pokemon_id", ID),
 		}
-		response, err := endpoint.Post(ctx, requestOpts...)
+		response, err := endpoint.Get(ctx, requestOpts...)
 		if response == nil && err != nil {
 			log.Error(ctx, ErrCantPerformGet.Error(), log.String("response error:", err.Error()))
 			return Pokemon{}, ErrCantPerformGet
@@ -67,7 +67,7 @@ func MakeGetTypes(httpClient rusty.Requester) (GetTypes, error) {
 	}
 
 	return func(ctx context.Context) (PokemonTypes, error) {
-		response, err := endpoint.Post(ctx)
+		response, err := endpoint.Get(ctx)
 		if response == nil && err != nil {
 			log.Error(ctx, ErrCantPerformGet.Error(), log.String("response error:", err.Error()))
 			return PokemonTypes{}, ErrCantPerformGet

--- a/sql/pokemons_pokemon.sql
+++ b/sql/pokemons_pokemon.sql
@@ -34,7 +34,7 @@ CREATE TABLE `pokemon` (
   `speed` int NOT NULL,
   `height` int NOT NULL,
   `weight` int NOT NULL,
-  `created` tinyint(1) NOT NULL DEFAULT '0',
+  `custom` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_UNIQUE` (`id`),
   UNIQUE KEY `name_UNIQUE` (`name`)


### PR DESCRIPTION
## Description
- Addition of a service layer in the endpoint Create V1 to handle logic and avoid handler communicate with DB directly
- DB field param change to custom, its more semantic
- Rest call verb change to Get, Post was wrong 
- Injections function improve, deleting useless error

### Transactions / Endpoints
- [ ] All
- [ ] GET /pokemons/v1
- [ ] GET /pokemons/types/v1
- [X] POST /pokemon/v1
- [ ] GET /pokemon/id/:pokemon_id/v1
